### PR TITLE
feat: 支持 markdown 語法

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@umijs/route-utils": "^2.0.0",
     "@wangeditor/editor": "^5.1.23",
     "@wangeditor/editor-for-react": "^1.0.6",
+    "@wangeditor/plugin-md": "^1.0.0",
     "antd": "^4.20.0",
     "classnames": "^2.3.0",
     "lodash": "^4.17.0",

--- a/src/pages/MyEditor/index.tsx
+++ b/src/pages/MyEditor/index.tsx
@@ -1,4 +1,6 @@
 import '@wangeditor/editor/dist/css/style.css' // 引入 css
+import { Boot } from '@wangeditor/editor'
+import markdownModule from '@wangeditor/plugin-md'
 
 import type { FC } from 'react';
 import { useState, useEffect } from 'react'
@@ -46,6 +48,9 @@ const createTree = (arr: { type: string; children: any; }[]) => {
     const head = arr[0];
     for (let i = 0; i < arr.length; i++) {
         const item = arr[i];
+        if (item.children[0].text.trim() === '') {
+            continue
+        }
         if (isEqual(head.type, item.type)) {
             const converedItem = convert(item);
             result.push(converedItem);
@@ -56,20 +61,17 @@ const createTree = (arr: { type: string; children: any; }[]) => {
     return result;
 };
 
-const treeOneToNode = (node: TreeOne) => ({
-    type: node.type,
-    children: [{
-        text: node.title
-    }]
-})
 interface Iprops {
     setTreeFunc?: Function
     scrollItem?: TreeOne
 }
 const MyEditor: FC<Iprops> = (props: Iprops) => {
+    Boot.registerModule(markdownModule)
+
     const { setTreeFunc } = props
     // editor 实例
     const [editor, setEditor] = useState<IDomEditor | null>(null)
+
     const [editorContent, setEditorContent] = useState([])
     // 工具栏配置
     const toolbarConfig: Partial<IToolbarConfig> = {}


### PR DESCRIPTION
## 需求
支持 markdown 語法
## 实现方案
1. https://github.com/wangeditor-team/wangEditor/issues/108 回答的 wangEditor-plugin-md 插件支持，注册编辑器前先引入支持后使用即可
## 实现效果
![10](https://user-images.githubusercontent.com/72444478/216068922-689ae6e9-fbee-4982-aa98-0585827b8977.gif)


